### PR TITLE
Fixed websocket handshake failure if server is running on "ws://localhos...

### DIFF
--- a/src/main/java/ws/wamp/jawampa/transport/SimpleWampWebsocketListener.java
+++ b/src/main/java/ws/wamp/jawampa/transport/SimpleWampWebsocketListener.java
@@ -151,7 +151,7 @@ public class SimpleWampWebsocketListener {
             }
             pipeline.addLast(new HttpServerCodec());
             pipeline.addLast(new HttpObjectAggregator(65536));
-            pipeline.addLast(new WampServerWebsocketHandler(uri.getPath(), router));
+            pipeline.addLast(new WampServerWebsocketHandler(uri.getPath().length()==0 ? "/" : uri.getPath(), router));
             pipeline.addLast(new WebSocketServerHandler(uri));
         }
     }


### PR DESCRIPTION
Fixed websocket handshake failure if server is running on "ws://localhost:8080"

below are shown actuall handshake messages:
GET / HTTP/1.1
Upgrade: websocket
Connection: Upgrade
Sec-WebSocket-Key: qA5FUwqKwq7RShm2iMzxew==
Host: localhost:8080
Sec-WebSocket-Origin: http://localhost:8080
Sec-WebSocket-Protocol: wamp.2.json,wamp.2.msgpack
Sec-WebSocket-Version: 13

HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Content-Length: 117

<html><head><title>Wamp Router</title></head><body><h1>This server provides
a wamp router on path </h1></body></html>

on investigation noticed that:
URI.create("ws://localhost:8080").getPath() returns empty string
the current code expects it to return "/"