### PR TITLE
Add IntelliJ project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Maven
 /target/
+
+# IntelliJ
+/.idea
+*.iml


### PR DESCRIPTION
Allows easier hacking on project for those using IntelliJ.