### PR TITLE
adds encoding to pom.xml to avoid warning during maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     </developers>
   
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
     <modules>


### PR DESCRIPTION
see https://maven.apache.org/general.html#encoding-warning