### PR TITLE
ObjectMapper#writeValueAsString(node) might throw UnsupportedOperationException

### DIFF
--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/WampSerializationHandler.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/WampSerializationHandler.java
@@ -62,7 +62,7 @@ public class WampSerializationHandler extends MessageToMessageEncoder<WampMessag
             objectMapper.writeValue(outStream, node);
 
             if (logger.isDebugEnabled()) {
-                logger.debug("Serialized Wamp Message: {}", objectMapper.writeValueAsString(node));
+                logger.debug("Serialized Wamp Message: {}", node.toString());
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
When ObjectMapper is configured to use MessagePack
ObjectMapper#writeValueAsString(node) throws:
java.lang.UnsupportedOperationException
 at org.msgpack.jackson.dataformat.MessagePackFactory.createGenerator(MessagePackFactory.java:41)
 at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:2323)
 at ws.wamp.jawampa.transport.netty.WampSerializationHandler.encode(WampSerializationHandler.java:65)