### PR TITLE
Disconnected state right after RPC call 

### DIFF
--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampClientConnectorProvider.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampClientConnectorProvider.java
@@ -120,7 +120,9 @@ public class NettyWampClientConnectorProvider implements IWampConnectorProvider 
             }
             
             final String subProtocols = WampSerialization.makeWebsocketSubprotocolList(serializations);
-            
+
+            final int maxFramePayloadLength = (nettyConfig == null )? NettyWampConnectionConfig.DEFAULT_MAX_FRAME_PAYLOAD_LENGTH : nettyConfig.getMaxFramePayloadLength();
+
             // Return a factory that creates a channel for websocket connections
             return new IWampConnector() {
                 @Override
@@ -137,7 +139,7 @@ public class NettyWampClientConnectorProvider implements IWampConnectorProvider 
                     
                     final WebSocketClientHandshaker handshaker = WebSocketClientHandshakerFactory.newHandshaker(
                         uri, WebSocketVersion.V13, subProtocols,
-                        false, new DefaultHttpHeaders());
+                        false, new DefaultHttpHeaders(), maxFramePayloadLength);
                     
                     /**
                      * Netty handler for that receives and processes WampMessages and state
@@ -262,7 +264,7 @@ public class NettyWampClientConnectorProvider implements IWampConnectorProvider 
                         protected void initChannel(SocketChannel ch) {
                         ChannelPipeline p = ch.pipeline();
                         if (sslCtx0 != null) {
-                            p.addLast(sslCtx0.newHandler(ch.alloc(), 
+                            p.addLast(sslCtx0.newHandler(ch.alloc(),
                                                          uri.getHost(),
                                                          port));
                         }

--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
@@ -4,12 +4,17 @@ import io.netty.handler.ssl.SslContext;
 import ws.wamp.jawampa.connection.IWampClientConnectionConfig;
 
 public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
+
+    static final int DEFAULT_MAX_FRAME_PAYLOAD_LENGTH = 65535;
+
     SslContext sslContext;
-    
-    NettyWampConnectionConfig(SslContext sslContext) {
+    int maxFramePayloadLength;
+
+    NettyWampConnectionConfig(SslContext sslContext, int maxFramePayloadLength) {
         this.sslContext = sslContext;
+        this.maxFramePayloadLength = maxFramePayloadLength;
     }
-    
+
     /**
      * the SslContext which will be used to create Ssl connections to the WAMP
      * router. If this is set to null a default (unsecure) SSL client context will be created
@@ -18,15 +23,20 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
     public SslContext sslContext() {
         return sslContext;
     }
-    
+
+    public int getMaxFramePayloadLength() {
+        return maxFramePayloadLength;
+    }
+
     /**
      * Builder class that must be used to create a {@link NettyWampConnectionConfig}
      * instance.
      */
     public static class Builder {
-        
+
         SslContext sslContext;
-    
+        int maxFramePayloadLength = DEFAULT_MAX_FRAME_PAYLOAD_LENGTH;
+
         /**
          * Allows to set the SslContext which will be used to create Ssl connections to the WAMP
          * router. If this is set to null a default (unsecure) SSL client context will be created
@@ -38,9 +48,14 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
             this.sslContext = sslContext;
             return this;
         }
-        
+
+        public Builder withMaxFramePayloadLength(int maxFramePayloadLength){
+            this.maxFramePayloadLength = maxFramePayloadLength;
+            return this;
+        }
+
         public NettyWampConnectionConfig build() {
-            return new NettyWampConnectionConfig(sslContext);
+            return new NettyWampConnectionConfig(sslContext, maxFramePayloadLength);
         }
     }
 }

--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
@@ -50,7 +50,7 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
         }
 
         public Builder withMaxFramePayloadLength(int maxFramePayloadLength){
-            if ( maxFramePayloadLength < 0 ){
+            if ( maxFramePayloadLength <= 0 ){
                 throw new IllegalArgumentException("maxFramePayloadLength parameter cannot be negative");
             }
             this.maxFramePayloadLength = maxFramePayloadLength;

--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
@@ -50,6 +50,9 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
         }
 
         public Builder withMaxFramePayloadLength(int maxFramePayloadLength){
+            if ( maxFramePayloadLength < 0 ){
+                throw new IllegalArgumentException("maxFramePayloadLength parameter cannot be negative");
+            }
             this.maxFramePayloadLength = maxFramePayloadLength;
             return this;
         }


### PR DESCRIPTION
I found one strange behavior while trying to call RPC procedure. After call I get Disconnected state that invokes error.transport_closed error for my MY_PROCEDURE. What can be wrong with it? I have not get some errors - just disconnect. My app is some sort of chat and it happens not for all data (i trying to get history for user ) - but 100% reproducable for some users. If it is data problem - why it is not just Throwable with error? Now it looks like a magic - call RPC - disconnected state. And it is not a server problem because same data on iOS handled correctly. 

protected final EnumSet<CallFlags> flags = EnumSet.of(CallFlags.DiscloseMe);

final ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.instance);
 arrayNode.add(someData);
 arrayNode.add(someData2);
client.call(MY_PROCEDURE, flags, arguments, null).subscribe(new Action1<Reply>() {...