### PR TITLE
Inner Process Clients and Session Meta API.

### DIFF
--- a/jawampa-core/src/main/java/ws/wamp/jawampa/WampRouterBuilder.java
+++ b/jawampa-core/src/main/java/ws/wamp/jawampa/WampRouterBuilder.java
@@ -34,6 +34,8 @@ public class WampRouterBuilder {
     
     Map<String, RealmConfig> realms = new HashMap<String, RealmConfig>();
 
+    boolean metaApiEnabled;
+    
     public WampRouterBuilder() {
         
     }
@@ -47,7 +49,7 @@ public class WampRouterBuilder {
         if (realms.size() == 0)
             throw new ApplicationError(ApplicationError.INVALID_REALM);
         
-        return new WampRouter(realms);
+        return new WampRouter(realms, metaApiEnabled);
     }
     
     /**
@@ -95,6 +97,12 @@ public class WampRouterBuilder {
         // Insert the new realm configuration
         this.realms.put(realmName, realmConfig);
         
+        return this;
+    }
+    
+    public WampRouterBuilder withMetaApiEnabled()
+    {
+        metaApiEnabled = true;
         return this;
     }
 }

--- a/jawampa-examples/src/main/java/ws/wamp/jawampa/examples/ServerTest.java
+++ b/jawampa-examples/src/main/java/ws/wamp/jawampa/examples/ServerTest.java
@@ -50,39 +50,43 @@ public class ServerTest {
     
     public void start() {
         
-        WampRouterBuilder routerBuilder = new WampRouterBuilder();
+        URI serverUri = URI.create("ws://0.0.0.0:8080/ws1");
+        
         WampRouter router;
-        try {
-            routerBuilder.addRealm("realm1");
-            router = routerBuilder.build();
-        } catch (ApplicationError e1) {
-            e1.printStackTrace();
-            return;
+        SimpleWampWebsocketListener server;
+        {
+            WampRouterBuilder routerBuilder = new WampRouterBuilder();
+            try {
+                routerBuilder.addRealm("realm1");
+                router = routerBuilder.build();
+                
+                server = new SimpleWampWebsocketListener(router, serverUri, null);
+                server.start();
+                
+            } catch (ApplicationError e1) {
+                e1.printStackTrace();
+                return;
+            }
         }
         
-        URI serverUri = URI.create("ws://0.0.0.0:8080/ws1");
-        SimpleWampWebsocketListener server;
-
-        IWampConnectorProvider connectorProvider = new NettyWampClientConnectorProvider();
-        WampClientBuilder builder = new WampClientBuilder();
-
         // Build two clients
         final WampClient client1;
         final WampClient client2;
-        try {
-            server = new SimpleWampWebsocketListener(router, serverUri, null);
-            server.start();
-            
-            builder.withConnectorProvider(connectorProvider)
-                   .withUri("ws://localhost:8080/ws1")
-                   .withRealm("realm1")
-                   .withInfiniteReconnects()
-                   .withReconnectInterval(3, TimeUnit.SECONDS);
-            client1 = builder.build();
-            client2 = builder.build();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return;
+        {
+            IWampConnectorProvider connectorProvider = new NettyWampClientConnectorProvider();
+            WampClientBuilder builder = new WampClientBuilder();
+            try {
+                builder.withConnectorProvider(connectorProvider)
+                       .withUri("ws://localhost:8080/ws1")
+                       .withRealm("realm1")
+                       .withInfiniteReconnects()
+                       .withReconnectInterval(3, TimeUnit.SECONDS);
+                client1 = builder.build();
+                client2 = builder.build();
+            } catch (Exception e) {
+                e.printStackTrace();
+                return;
+            }
         }
 
         client1.statusChanged().subscribe(new Action1<WampClient.State>() {

--- a/jawampa-examples/src/main/java/ws/wamp/jawampa/examples/ServerTest.java
+++ b/jawampa-examples/src/main/java/ws/wamp/jawampa/examples/ServerTest.java
@@ -89,7 +89,7 @@ public class ServerTest {
         }
 
         // Build inner process client2
-        final WampClient client2 = router.createInnerProccessClient("realm1");
+        final WampClient client2 = router.createInnerProcessClient("realm1");
         
         // Setup client1
         client1.statusChanged().subscribe(new Action1<WampClient.State>() {


### PR DESCRIPTION
There are two features in this pull proposal: one feature is an ability to create in process clients, which are connected to the given router:
 - Router::createInnerProcessClinet()
And the session meta API which publishes to the channel for when a client connects or disconnects. This is an advanced profile feature described here:
 - https://github.com/wamp-proto/wamp-proto/blob/master/rfc/text/advanced/ap_session_meta_api.md 

Affectively now you can subscribe to "wamp.session.on_leave" channel and get notified when any other clients leaves (disconnects) from the router.

Two channels are supported: "wamp.session.on_join" and "wamp.session.on_leave".

Fell free to criticise any part of the change or whole. I am happy to incorporate any feedback especially quality related.

Cheers,
Alex