### PR TITLE
Adds support for custom HTTP headers

### DIFF
--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampClientConnectorProvider.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampClientConnectorProvider.java
@@ -48,6 +48,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
@@ -122,6 +123,7 @@ public class NettyWampClientConnectorProvider implements IWampConnectorProvider 
             final String subProtocols = WampSerialization.makeWebsocketSubprotocolList(serializations);
 
             final int maxFramePayloadLength = (nettyConfig == null )? NettyWampConnectionConfig.DEFAULT_MAX_FRAME_PAYLOAD_LENGTH : nettyConfig.getMaxFramePayloadLength();
+            final HttpHeaders httpHeaders = (nettyConfig == null) ? new DefaultHttpHeaders() : nettyConfig.getHttpHeaders();
 
             // Return a factory that creates a channel for websocket connections
             return new IWampConnector() {
@@ -139,7 +141,7 @@ public class NettyWampClientConnectorProvider implements IWampConnectorProvider 
                     
                     final WebSocketClientHandshaker handshaker = WebSocketClientHandshakerFactory.newHandshaker(
                         uri, WebSocketVersion.V13, subProtocols,
-                        false, new DefaultHttpHeaders(), maxFramePayloadLength);
+                        false, httpHeaders, maxFramePayloadLength);
                     
                     /**
                      * Netty handler for that receives and processes WampMessages and state

--- a/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
+++ b/jawampa-netty/src/main/java/ws/wamp/jawampa/transport/netty/NettyWampConnectionConfig.java
@@ -1,5 +1,7 @@
 package ws.wamp.jawampa.transport.netty;
 
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.ssl.SslContext;
 import ws.wamp.jawampa.connection.IWampClientConnectionConfig;
 
@@ -9,10 +11,12 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
 
     SslContext sslContext;
     int maxFramePayloadLength;
+    HttpHeaders httpHeaders;
 
-    NettyWampConnectionConfig(SslContext sslContext, int maxFramePayloadLength) {
+    NettyWampConnectionConfig(SslContext sslContext, int maxFramePayloadLength, HttpHeaders httpHeaders) {
         this.sslContext = sslContext;
         this.maxFramePayloadLength = maxFramePayloadLength;
+        this.httpHeaders = httpHeaders;
     }
 
     /**
@@ -28,6 +32,10 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
         return maxFramePayloadLength;
     }
 
+    public HttpHeaders getHttpHeaders() {
+        return httpHeaders;
+    }
+
     /**
      * Builder class that must be used to create a {@link NettyWampConnectionConfig}
      * instance.
@@ -36,6 +44,7 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
 
         SslContext sslContext;
         int maxFramePayloadLength = DEFAULT_MAX_FRAME_PAYLOAD_LENGTH;
+        HttpHeaders httpHeaders = new DefaultHttpHeaders();
 
         /**
          * Allows to set the SslContext which will be used to create Ssl connections to the WAMP
@@ -57,8 +66,19 @@ public class NettyWampConnectionConfig implements IWampClientConnectionConfig {
             return this;
         }
 
+        /**
+         * Add a new header with the specified name and value.
+         * @param name The name of the header being added.
+         * @param value The value of the header being added.
+         * @return The {@link Builder} object.
+         */
+        public Builder withHttpHeader(String name, Object value) {
+            this.httpHeaders.add(name, value);
+            return this;
+        }
+
         public NettyWampConnectionConfig build() {
-            return new NettyWampConnectionConfig(sslContext, maxFramePayloadLength);
+            return new NettyWampConnectionConfig(sslContext, maxFramePayloadLength, httpHeaders);
         }
     }
 }


### PR DESCRIPTION
Updates NettyWampConnectionConfig to allow a client to provide
additional headers to include in the initial HTTP connection, such as a
user agent string.