### PR TITLE
Updated Netty version (current is buggy)

### DIFF
--- a/jawampa-netty/pom.xml
+++ b/jawampa-netty/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
     <parent>
       <groupId>ws.wamp.jawampa</groupId>
       <artifactId>jawampa-parent</artifactId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.0.24.Final</version>
+      <version>4.1.11.Final</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
- Updated netty-codec-http version to current.
- Removed meaningless whitespace.

Version 4.0.24 is buggy and silents Traceback errors that includes errors giving clue why jawampa is not working on some devices -  https://github.com/Matthias247/jawampa/issues/105
It is needed at least version 4.0.26 to properly show Tracebacks.
It is safe to update to version 4.0.40 without any other code changes.

I've updated to the latest 4.1.11.Final with single incompatible change - see line 112