### PR TITLE
Add support for arrays in events and results in the client

### DIFF
--- a/jawampa-core/src/main/java/ws/wamp/jawampa/WampClient.java
+++ b/jawampa-core/src/main/java/ws/wamp/jawampa/WampClient.java
@@ -429,7 +429,12 @@ public class WampClient {
                 if (ev.arguments == null || ev.arguments.size() < 1)
                     throw OnErrorThrowable.from(new ApplicationError(ApplicationError.MISSING_VALUE));
 
-                JsonNode eventNode = ev.arguments.get(0);
+                JsonNode eventNode = null;
+                if (!eventClass.isArray()) {
+                	eventNode = ev.arguments.get(0);
+                } else {
+                	eventNode = ev.arguments;
+                }
                 if (eventNode.isNull()) return null;
 
                 T eventValue;
@@ -489,7 +494,12 @@ public class WampClient {
                 if (ev.arguments == null || ev.arguments.size() < 1)
                     throw OnErrorThrowable.from(new ApplicationError(ApplicationError.MISSING_VALUE));
 
-                JsonNode eventNode = ev.arguments.get(0);
+                JsonNode eventNode = null;
+                if (!eventClass.isArray()) {
+                	eventNode = ev.arguments.get(0);
+                } else {
+                	eventNode = ev.arguments;
+                }
                 if (eventNode.isNull()) return null;
 
                 T eventValue;
@@ -748,8 +758,13 @@ public class WampClient {
                 
                 if (reply.arguments == null || reply.arguments.size() < 1)
                     throw OnErrorThrowable.from(new ApplicationError(ApplicationError.MISSING_RESULT));
-                    
-                JsonNode resultNode = reply.arguments.get(0);
+                JsonNode resultNode = null;
+                
+                if (!returnValueClass.isArray()) {
+                    resultNode = reply.arguments.get(0);                	
+                } else {
+                	resultNode = reply.arguments;
+                }
                 if (resultNode.isNull()) return null;
                 
                 T result;


### PR DESCRIPTION
Currently there is no issue sending lists and arrays in results or events but the client only takes the first element of the returned list as it is hardcoded.
Handling Iterables needs a new API as internal class gets deleted the due to type erasure and you end with a list/set of JsonNodes. We will need to add a new call or subscribe api that uses a TypeReference to properly support that, that leads to more changes in the internal code, so I left that for a future improvement.

Handling arrays is as simple as just letting the jackson parse all the elements received in the response so I added support for it.