### PR TITLE
Change minimum valid ID to 1

### DIFF
--- a/jawampa-core/src/main/java/ws/wamp/jawampa/internal/IdValidator.java
+++ b/jawampa-core/src/main/java/ws/wamp/jawampa/internal/IdValidator.java
@@ -22,7 +22,7 @@ package ws.wamp.jawampa.internal;
  */
 public class IdValidator {
     
-    public static final long MIN_VALID_ID = 0L;
+    public static final long MIN_VALID_ID = 1L;
     public static final long MAX_VALID_ID = 9007199254740992L; // 2^53
     
     /**


### PR DESCRIPTION
Wamp spec ([S5.1.2.ID](https://wamp-proto.org/static/rfc/draft-oberstet-hybi-crossbar-wamp.html#ids)) says minimum valid ID is 1, not 0.